### PR TITLE
Add prototype encrypt_comm security-hardening refactoring action

### DIFF
--- a/docs/security-refactoring-proposal.md
+++ b/docs/security-refactoring-proposal.md
@@ -1,0 +1,91 @@
+# Proposal: a security dimension for EASIER
+
+## 1. Gap analysis
+
+EASIER currently optimizes UML+MARTE/DAM architecture models along six axes: performance
+antipatterns (`pas`), reliability, energy, power, economic cost, and refactoring cost (`changes`),
+plus response-time variants. There is no security dimension, and no groundwork for one:
+
+- **No security stereotypes** exist in any MARTE/DAM profile fragment vendored or referenced by
+  this project (`easier-reliability/src/main/resources/umlprofiles/{MARTE,DAM}.profile.uml`, the
+  MagicDraw MARTE fragments under `easier-refactoringLibrary/model/uml/BGCS/`). MARTE/DAM usage
+  here is exclusively performance/reliability/energy-oriented (`GaExecHost`, `GaCommChannel`,
+  `RtUnit`, `GaScenario`, `GaStep`, `DaComponent`, `DaConnector`, `DaFailure`).
+- **No security-named refactoring actions, EOL/EVL scripts, or objectives** exist anywhere in
+  `easier-uml`/`easier-refactoringLibrary`/`Configurator`.
+- Elements literally named "security" in the case-study models are coincidental: `eshopper.uml`
+  has a `security` node/artifact that is just one of several ordinary e-commerce microservice
+  containers (alongside `wishlist`, etc.); `acmeair.uml` has `Auth`/`ValidateId` components that
+  are ordinary login functionality, not hardened access control.
+- **`GaCommChannel` — the one MARTE stereotype that could plausibly represent a network link's
+  security-relevant properties — is dead code.** It's referenced only in an unused helper
+  (`easier-refactoringLibrary/evl/library/node.eol`'s `isNetworkLink()`/network-usage calculation)
+  and is never actually applied to any `CommunicationPath` in any real case-study model. Worse,
+  `CommunicationPath` elements are unnamed (`name=""`) in every case study checked, and every
+  existing action that touches links (`UMLCloneNode`'s `cloneLink()`) handles them *in bulk* via
+  `Node.getDirectlyLinkedNode()` — there is no precedent anywhere in this codebase for selecting
+  one specific link by identity. This directly shaped the prototype's design (Section 3): a new
+  action targeting "encrypt this one specific channel" has no reusable selection mechanism to
+  build on, so the prototype instead targets a `Node`, exactly like `UMLResourceScaling` already
+  does.
+
+## 2. Proposed lightweight `Security` profile (design only, not implemented this pass)
+
+A proper implementation would eventually want dedicated stereotypes, so security properties are
+queryable structurally (by an EVL antipattern rule, say) rather than inferred from a `Comment`'s
+text, as the Section 3 prototype does as an interim measure:
+
+| Stereotype | Extends | Tagged values | Purpose |
+|---|---|---|---|
+| `SecureChannel` | `Association` | `encryptionOverheadFactor: Real` | Marks a communication path as encrypted, with a performance cost. |
+| `AccessControlled` | `Component` / `Node` | `authRequired: Boolean`, `minPrivilegeLevel: Integer` | Marks an element as access-gated. |
+| `AuditLogged` | `Component` | `logOverheadFactor: Real` | Marks an element as producing an audit trail, with a performance cost. |
+
+This requires proper EMF/Ecore profile registration (a `.profile.uml`/`.ecore`/`.genmodel` triple,
+a pathmap URI, and re-generating/registering the profile the way the vendored MARTE/DAM profiles
+are) — a materially bigger lift than a single prototype action warrants, and is deferred.
+
+## 3. Candidate refactoring actions
+
+Each candidate is mapped to a security-tactic category (Bass, Clements & Kazman's taxonomy:
+Detect / Resist / React / Recover attacks), a structural transformation, its target element type,
+and the existing EASIER action it's most directly analogous to (i.e., what to copy as a starting
+point).
+
+| Action | Tactic | Transformation | Target | Analogous to | Status |
+|---|---|---|---|---|---|
+| `EncryptComm` | Resist | Reduce a node's `GaExecHost::speedFactor` (crypto CPU overhead) + attach a marker `Comment` | `Node` | `UMLResourceScaling` | **Prototyped this pass** |
+| `InsertAuthGateway` | Resist / Detect | Insert a new gateway `Component`, reroute messages through it | `Component`/`Message` | `UMLMvOperationToNCToNN` | Proposed |
+| `IsolateOnDedicatedNode` | Resist | Move a sensitive `Component` onto a new, dedicated `Node` | `Component` | `UMLMvComponentToNN` | Proposed |
+| `AddAuditProbe` | Detect | Attach a logging marker/tag to a component's message flow | `Component` | `UMLChangePassiveResource` | Proposed |
+| `RestrictInterfaceExposure` | Resist (least privilege) | Remove unused/over-broad operations from a public `Interface`; cost = # operations removed | `Interface` | `UMLRemoveComponent`'s removal pattern | Proposed |
+
+`InsertAuthGateway`, `IsolateOnDedicatedNode`, `AddAuditProbe`, and `RestrictInterfaceExposure` are
+proposed at the design level only — not implemented in this pass.
+
+## 4. Objective-pipeline integration (design sketch, not wired this pass)
+
+Objectives are config-driven (`Configurator.getObjectivesList()`, a `List<String>`), and jMetal's
+objective-vector size derives from that list's length at construction (`UMLRProblem`/`RSolution`),
+so adding a new objective is primarily a wiring change, following the exact template `pas` already
+uses:
+
+1. A new `Secur-UML-MARTE.evl`, analogous to `easier-refactoringLibrary/evl/AP-UML-MARTE.evl`,
+   with critiques like `UnhardenedNode` (a `Node` with no `EASIER-SECURITY:`-marked `Comment` and
+   at least one outbound `CommunicationPath`) or `OverprivilegedInterface`.
+2. A `easier-security` submodule, mirroring `easier-reliability`'s clean
+   `Model → extractor → compute()` shape (`UMLModelPapyrus` → a domain extractor → a `compute()`
+   returning a `double`) — `easier-reliability`'s entire API surface is 3 constructor/method calls,
+   a good template.
+3. Registration in `ObjectiveEstimator`: a `Configurator.SECURITY_LABEL` constant, a
+   `security(...)` compute method, entries in `initObjectives()`/`computeObjectives()`, and adding
+   the label to the `knownExactLabels` set in `setConsideredObjectives()`.
+
+## 5. Stated limitation
+
+LQN (the queueing-network formalism EASIER solves models against via `lqns`) can express a
+security control's **performance overhead** — an extra task/entry/activity with added demand — but
+cannot express an abstract security *guarantee* (confidentiality, correctness of an access-control
+policy). Any resulting metric from Section 4 would measure overhead and/or the presence/absence of
+mitigations in the model, not verified security correctness. This should be stated plainly
+wherever such a metric is reported, to avoid overclaiming what it means.

--- a/easier-core/src/main/java/it/univaq/disim/sealab/metaheuristic/utils/Configurator.java
+++ b/easier-core/src/main/java/it/univaq/disim/sealab/metaheuristic/utils/Configurator.java
@@ -56,7 +56,7 @@ public class Configurator {
 
 	// For testing purposes it does not contain the tactics
 	@Parameter(names = {"-brf","--baselineRefactoringFactor"},  splitter = SemiColonSplitter.class, description = "The ordered list of baseline refactoring factors of Refactoring actions")
-	private List<String> brfs_list = List.of("clone:1.23","moc:1.23","mcnn:1.23","moncnn:1.23");
+	private List<String> brfs_list = List.of("clone:1.23","moc:1.23","mcnn:1.23","moncnn:1.23","encrypt_comm:1.23");
 	public List<String> getBrfList(){
 		return brfs_list;
 	}

--- a/easier-uml/src/main/java/it/univaq/disim/sealab/metaheuristic/actions/uml/RefactoringActionFactory.java
+++ b/easier-uml/src/main/java/it/univaq/disim/sealab/metaheuristic/actions/uml/RefactoringActionFactory.java
@@ -54,6 +54,8 @@ public class RefactoringActionFactory {
                         return new UMLRemoveNode(availableElements, initialElements, modelContents);
                     case "remove_component":
                         return new UMLRemoveComponent(availableElements, initialElements, modelContents);
+                    case "encrypt_comm":
+                        return new UMLEncryptComm(availableElements, initialElements, modelContents);
                     default:
                         return null;
                 }

--- a/easier-uml/src/main/java/it/univaq/disim/sealab/metaheuristic/actions/uml/UMLEncryptComm.java
+++ b/easier-uml/src/main/java/it/univaq/disim/sealab/metaheuristic/actions/uml/UMLEncryptComm.java
@@ -1,0 +1,136 @@
+package it.univaq.disim.sealab.metaheuristic.actions.uml;
+
+import it.univaq.disim.sealab.epsilon.eol.EOLStandalone;
+import it.univaq.disim.sealab.epsilon.eol.EasierUmlModel;
+import it.univaq.disim.sealab.metaheuristic.evolutionary.UMLRSolution;
+import it.univaq.disim.sealab.metaheuristic.utils.Configurator;
+import it.univaq.disim.sealab.metaheuristic.utils.EasierException;
+import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * Prototype security-hardening action: models "encrypt this node's outbound communication" as a
+ * performance-costed refactoring, reusing the existing GaExecHost::speedFactor mechanism
+ * (UMLResourceScaling's tag) so the effect flows through the unmodified easier-uml2lqn pipeline.
+ * See docs/security-refactoring-proposal.md for the full design rationale.
+ */
+public class UMLEncryptComm extends UMLRefactoringAction {
+
+    private final static Path eolModulePath;
+
+    static {
+        eolModulePath = Paths.get(FileSystems.getDefault().getPath("").toAbsolutePath().toString(), "..",
+                "easier-refactoringLibrary", "easier-ref-operations", "encrypt_comm.eol");
+    }
+
+    private String taggedValue;
+    private double overheadFactor;
+
+    public UMLEncryptComm() {
+        name = "encrypt_comm";
+    }
+
+    public UMLEncryptComm(Map<String, Set<String>> availableElements, Map<String, Set<String>> sourceElements, Collection<?> modelContents)
+            throws EasierException {
+        this();
+
+        Set<String> availableNode = availableElements.get(Configurator.NODE_LABEL);
+        Set<String> targetElement = new HashSet<>();
+        targetElement.add(availableNode.stream().skip(new Random().nextInt(availableNode.size()-1)).findFirst()
+                .orElseThrow(() -> new EasierException("Error when extracting the target element in: " + this.getClass().getSimpleName())));
+        targetElements.put(Configurator.NODE_LABEL, targetElement);
+
+        // check whether the action is using an element created by another action
+        setIndependent(sourceElements);
+
+        // Extract a random tagged value for the action
+        taggedValue = "speedFactor";
+
+        // Encryption always costs performance: narrower, always-degrading range than
+        // UMLResourceScaling's general [0.5, 1.5] rescaling.
+        overheadFactor = JMetalRandom.getInstance().nextDouble(0.7, 0.95);
+        refactoringCost = computeArchitecturalChanges();
+    }
+
+    @Override
+    public void execute(EasierUmlModel contextModel) throws EasierException {
+        EOLStandalone executor = new EOLStandalone();
+
+        try {
+            executor.setModel(contextModel);
+            executor.setSource(eolModulePath);
+
+            String targetNodeName = targetElements.get(Configurator.NODE_LABEL).iterator().next();
+            executor.setParameter(targetNodeName, "String", "targetNodeName");
+            executor.setParameter(String.valueOf(overheadFactor), "Real", "overheadFactor");
+            executor.setParameter(
+                    String.format("EASIER-SECURITY: encryption enabled (overhead factor %s)", overheadFactor),
+                    "String", "securityComment");
+
+            executor.execute();
+        } catch (EolRuntimeException e) {
+            String message = String.format("Error in execution the eolmodule %s%n ", eolModulePath);
+            message += e.getMessage();
+            throw new EasierException(message);
+        }
+        executor.clearMemory();
+    }
+
+    @Override
+    public String getTargetType() {
+        return Configurator.NODE_LABEL;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Encrypt communication: %s of: %s with: %s",
+                taggedValue,
+                targetElements.get(Configurator.NODE_LABEL).iterator().next(),
+                overheadFactor);
+    }
+
+    public String toCSV() {
+        return String.format("%s,%s,,,%s,%s",
+                name,
+                targetElements.get(Configurator.NODE_LABEL).iterator().next(),
+                taggedValue,
+                overheadFactor);
+    }
+
+    private double computeArchitecturalChanges() {
+        return 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UMLEncryptComm other = (UMLEncryptComm) obj;
+
+        if (!targetElements.equals(other.targetElements))
+            return false;
+        if (!taggedValue.equals(other.taggedValue))
+            return false;
+        if (overheadFactor != other.overheadFactor)
+            return false;
+        return true;
+    }
+
+    public String getTaggedValue() {
+        return taggedValue;
+    }
+
+    public String getOverheadFactor() {
+        return String.valueOf(overheadFactor);
+    }
+
+}

--- a/easier-uml/src/test/java/it/univaq/disim/sealab/metaheuristic/actions/uml/UMLEncryptCommTest.java
+++ b/easier-uml/src/test/java/it/univaq/disim/sealab/metaheuristic/actions/uml/UMLEncryptCommTest.java
@@ -1,0 +1,80 @@
+package it.univaq.disim.sealab.metaheuristic.actions.uml;
+
+import it.univaq.disim.sealab.metaheuristic.domain.UMLEasierModel;
+import it.univaq.disim.sealab.metaheuristic.utils.Configurator;
+import it.univaq.disim.sealab.metaheuristic.utils.EasierException;
+import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UMLEncryptCommTest extends UMLRefactoringActionTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"cocome/simplified-cocome/cocome.uml", "train-ticket/train-ticket.uml",
+            "eshopper/eshopper.uml"})
+    void execute(String mPath) throws EasierException {
+        modelpath = getClass().getResource(BASE_PATH + mPath).getPath();
+        eModel = new UMLEasierModel(modelpath);
+        action = new UMLEncryptComm(eModel.getAvailableElements(), eModel.getInitialElements(), eModel.getAllContents());
+        assertDoesNotThrow(super::testExecute);
+    }
+
+    @Test
+    void testToString() throws EasierException {
+        String mPath = "cocome/simplified-cocome/cocome.uml";
+        modelpath = getClass().getResource(BASE_PATH + mPath).getPath();
+        eModel = new UMLEasierModel(modelpath);
+        action = new UMLEncryptComm(eModel.getAvailableElements(), eModel.getInitialElements(), eModel.getAllContents());
+
+        String targetNode = action.getTargetElements().get(Configurator.NODE_LABEL).iterator().next();
+        String result = action.toString();
+
+        assertTrue(result.startsWith("Encrypt communication:"), "Expected toString to start with the action label");
+        assertTrue(result.contains(targetNode), "Expected toString to contain the target node: " + targetNode);
+    }
+
+    @Test
+    void toCSV() throws EasierException {
+        numberOfCSVField = 6;
+        actionName = "encrypt_comm";
+        String mPath = "cocome/simplified-cocome/cocome.uml";
+        modelpath = getClass().getResource(BASE_PATH + mPath).getPath();
+        eModel = new UMLEasierModel(modelpath);
+        action = new UMLEncryptComm(eModel.getAvailableElements(), eModel.getInitialElements(), eModel.getAllContents());
+        super.testToCSV();
+    }
+
+    @Test
+    void computeArchitecturalChanges() throws EasierException, URISyntaxException, EolModelLoadingException {
+        String mPath = "cocome/simplified-cocome/cocome.uml";
+        modelpath = getClass().getResource(BASE_PATH + mPath).getPath();
+        eModel = new UMLEasierModel(modelpath);
+        action = new UMLEncryptComm(eModel.getAvailableElements(), eModel.getInitialElements(), eModel.getAllContents());
+        super.testComputeArchitecturalChanges();
+    }
+
+    @Test
+    void testEquals() throws EasierException {
+        String mPath = "cocome/simplified-cocome/cocome.uml";
+        modelpath = getClass().getResource(BASE_PATH + mPath).getPath();
+        eModel = new UMLEasierModel(modelpath);
+        action = new UMLEncryptComm(eModel.getAvailableElements(), eModel.getInitialElements(), eModel.getAllContents());
+        super.testEquals();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `UMLEncryptComm`, a prototype security-tactic action that models "encrypt this node's outbound communication" as a `GaExecHost::speedFactor` slowdown (crypto CPU overhead, uniform random in [0.7, 0.95]) plus a marker `Comment`, reusing `UMLResourceScaling`'s existing tag mechanism so it flows through the unmodified `easier-uml2lqn` pipeline unchanged.
- Registers `encrypt_comm` in `RefactoringActionFactory` and in `Configurator`'s default `brfs_list` (BRF `1.23`, matching the other default actions), so it's both randomly selectable by the mutation operator and correctly weighted into the `changes`/refactoring-cost objective (previously it would only ever get the implicit fallback weight and was never randomly selected at all, since `listOfActions()` is derived strictly from `brfs_list`).
- Adds `docs/security-refactoring-proposal.md`: gap analysis (no security stereotypes/objectives exist anywhere in the project today, `GaCommChannel` is dead code and never applied to any real `CommunicationPath`), a proposed (not implemented) lightweight `Security` UML profile, four other proposed-but-unimplemented security actions, a design sketch for wiring a future `security` objective, and a stated limitation that LQN can express performance overhead but not an abstract security guarantee.

Not included in this PR: a `PatientPortalModelTest` that was prototyped alongside this work depends on a new `patient-portal.uml` benchmark model that only exists as an uncommitted, untracked file in the local `easier-uml2lqnCaseStudy` submodule checkout — it was never pushed to that submodule's remote, so including the test here would break the build for anyone else. Happy to push that model to the submodule separately if wanted.

## Test plan
- [x] `easier-core` compiles cleanly with the `Configurator.brfs_list` change.
- [x] `UMLEncryptComm`/`RefactoringActionFactory` changes verified line-for-line against the existing, already-working `UMLResourceScaling` sibling action (same base class, same constructor/execute pattern) — no API drift.
- [ ] Full `easier-uml` reactor build/test run — blocked locally by a pre-existing, unrelated dependency-resolution issue in the `easier-reliability` submodule at its currently pinned commit (missing transitive POM for the vendored MARTE profile jar); reproduces identically on a clean `main` checkout, not caused by this change. Please run `UMLEncryptCommTest` and `RefactoringActionFactoryTest` in an environment with a working `easier-reliability` build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)